### PR TITLE
srcjar renamed to src.jar for Intellij

### DIFF
--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -141,7 +141,7 @@ openapi_gen = rule(
         ),
     },
     outputs = {
-        "codegen": "%{name}_codegen.srcjar",
+        "codegen": "%{name}_codegen.src.jar", # IntelliJ does not understand .srcjar
     },
     implementation = _impl,
 )


### PR DESCRIPTION
Intellij has big pain point not being able to show source unless added as jar file, which does not support srcjar file.