### PR TITLE
Add additional_properties and system_properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ are implemented in these rules yet but contributions are welcome. You can also r
         <p>Name of language to generate.</p>
         <p>If you wish to use a custom language, you'll need to create a jar containing your <a href="https://github.com/swagger-api/swagger-codegen#making-your-own-codegen-modules">custom codegen module</a>, then use <code>deps</code> to add the custom codegen module to the classpath.</p>
         <p>
-          Note, not all swagger codegen provided langugages generate the exact same source given the exact same set of arguments.
+          Note, not all swagger codegen provided languages generate the exact same source given the exact same set of arguments.
           Be aware of this in cases where you expect bazel not to perform a previous executed action for the same sources.
         </p>
       </td>
@@ -98,6 +98,34 @@ are implemented in these rules yet but contributions are welcome. You can also r
       <td>
         <code>String, optional</code>
         <p>package for invoker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>additional_properties</code></td>
+      <td>
+        <code>Dict of strings, optional</code>
+        <p>Additional properties that can be referenced by the codegen
+        templates. This allows setting parameters that you'd normally put in
+        <code>config.json</code>, for example the Java library template:</p>
+        <pre>
+    language = "java",
+    additional_properties = {
+        "library": "feign",
+    },</pre>
+      </td>
+    </tr>
+    <tr>
+      <td><code>system_properties</code></td>
+      <td>
+        <code>Dict of strings, optional</code>
+        <p>System properties to pass to swagger-codegen.  This allows setting parameters that you'd normally
+        set with <code>-D</code>, for example to disable test generation:</p>
+        <pre>
+    language = "java",
+    system_properties = {
+        "apiTests": "false",
+        "modelTests": "false",
+    },</pre>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ are implemented in these rules yet but contributions are welcome. You can also r
     },</pre>
       </td>
     </tr>
+    <tr>
+      <td><code>type_mappings</code></td>
+      <td>
+        <code>Dict of strings, optional</code>
+        <p>Allows control of the types used in generated code with
+        swagger-codegen's <code>--type-mappings</code> parameter. For example to
+        use Java 8's LocalDateTime class:</p>
+        <pre>
+    language = "java",
+    additional_properties = {
+        "dateLibrary": "java8",
+    },
+    type_mappings = {
+        "OffsetDateTime": "java.time.LocalDateTime",
+    },</pre>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -11,9 +11,9 @@ def openapi_repositories(swagger_codegen_cli_version="2.2.2", swagger_codegen_cl
         actual = '@io_bazel_rules_openapi_io_swagger_swagger_codegen_cli//jar',
     )
 
-def _comma_separated_properties(properties):
+def _comma_separated_pairs(pairs):
     return ",".join([
-        "{}={}".format(k, v) for k, v in properties.items()
+        "{}={}".format(k, v) for k, v in pairs.items()
     ])
 
 def _new_generator_command(ctx, gen_dir, rjars):
@@ -29,7 +29,7 @@ def _new_generator_command(ctx, gen_dir, rjars):
   )
 
   gen_cmd += ' -D "{properties}"'.format(
-      properties=_comma_separated_properties(ctx.attr.system_properties),
+      properties=_comma_separated_pairs(ctx.attr.system_properties),
   )
 
   additional_properties = dict(ctx.attr.additional_properties)
@@ -40,7 +40,11 @@ def _new_generator_command(ctx, gen_dir, rjars):
       additional_properties["hideGenerationTimestamp"] = "true"
 
   gen_cmd += ' --additional-properties "{properties}"'.format(
-      properties=_comma_separated_properties(additional_properties),
+      properties=_comma_separated_pairs(additional_properties),
+  )
+
+  gen_cmd += ' --type-mappings "{mappings}"'.format(
+      mappings=_comma_separated_pairs(ctx.attr.type_mappings),
   )
 
   if ctx.attr.api_package:
@@ -144,6 +148,7 @@ openapi_gen = rule(
         "model_package": attr.string(),
         "additional_properties": attr.string_dict(),
         "system_properties": attr.string_dict(),
+        "type_mappings": attr.string_dict(),
         "_java": attr.label(
             executable = True,
             cfg = "host",

--- a/test/BUILD
+++ b/test/BUILD
@@ -30,3 +30,12 @@ openapi_gen(
         "modelTests": "false",
     },
 )
+
+openapi_gen(
+    name = "petstore_java_bigdecimal",
+    language = "java",
+    spec = "petstore.yaml",
+    type_mappings = {
+        "Integer": "java.math.BigDecimal",
+    },
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,6 +2,31 @@ load("//openapi:openapi.bzl", "openapi_gen")
 
 openapi_gen(
     name = "petstore",
+    language = "go",
     spec = "petstore.yaml",
-    language = "go"
+)
+
+openapi_gen(
+    name = "petstore_java",
+    language = "java",
+    spec = "petstore.yaml",
+)
+
+openapi_gen(
+    name = "petstore_java_feign",
+    additional_properties = {
+        "library": "feign",
+    },
+    language = "java",
+    spec = "petstore.yaml",
+)
+
+openapi_gen(
+    name = "petstore_java_no_tests",
+    language = "java",
+    spec = "petstore.yaml",
+    system_properties = {
+        "apiTests": "false",
+        "modelTests": "false",
+    },
 )


### PR DESCRIPTION
These correspond to swagger-codegen's --additional-properties and -D
parameters. additional_properties is useful for configuring the codegen,
and system_properties is useful for selective generation.

Also, use hideGenerationTimestamp to make Java codegen deterministic.

Finally, add simple tests to make sure the examples in the README build.