### PR TITLE
Revert "feat: Enable using gen dir in srcs of other rules"

### DIFF
--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -68,17 +68,25 @@ def _new_generator_command(ctx, gen_dir, rjars):
 def _impl(ctx):
     jars = _collect_jars(ctx.attr.deps)
     (cjars, rjars) = (jars.compiletime, jars.runtime)
+    gen_dir = "{dirname}/{rule_name}".format(
+        dirname=ctx.file.spec.dirname,
+        rule_name=ctx.attr.name
+    )
     
     commands = [
       "mkdir -p {gen_dir}".format(
-            gen_dir = ctx.outputs.gen_dir.path,
+        gen_dir=gen_dir
       ),
-        _new_generator_command(ctx, ctx.outputs.gen_dir.short_path, rjars),
+      _new_generator_command(ctx, gen_dir, rjars),
+      # forcing a timestamp for deterministic artifacts
+      "find {gen_dir} -exec touch -t 198001010000 {{}} \;".format(
+         gen_dir=gen_dir
+      ),
       "{jar} cMf {target} -C {srcs} .".format(
-            jar = "%s/bin/jar" % ctx.attr._jdk[java_common.JavaRuntimeInfo].java_home,
-            target = ctx.outputs.codegen.path,
-            srcs = ctx.outputs.gen_dir.path,
-        ),
+          jar="%s/bin/jar" % ctx.attr._jdk[java_common.JavaRuntimeInfo].java_home,
+          target=ctx.outputs.codegen.path,
+          srcs=gen_dir
+      )
     ]
 
     inputs = ctx.files._jdk + [
@@ -87,7 +95,7 @@ def _impl(ctx):
     ] + list(cjars) + list(rjars)
     ctx.action(
         inputs=inputs,
-        outputs=[ctx.outputs.gen_dir, ctx.outputs.codegen],
+        outputs=[ctx.actions.declare_directory("%s" % (ctx.attr.name)), ctx.outputs.codegen],
         command=" && ".join(commands),
         progress_message="generating openapi sources %s" % ctx.label,
         arguments=[],
@@ -155,7 +163,6 @@ openapi_gen = rule(
     },
     outputs = {
         "codegen": "%{name}_codegen.srcjar",
-        "gen_dir": "%{name}_gen_dir",
     },
     implementation = _impl,
 )


### PR DESCRIPTION
Reverts meetup/rules_openapi#9

This change breaks the srcjar output, resulting in an empty file. Before meetup/rules_openapi#9:

```
➜  git checkout 7e3e826a7f479efce458592d8639f92cb619ce73
Previous HEAD position was 1c91e94 Merge pull request #9 from mrmeku/gen_srcs
HEAD is now at 7e3e826 Merge pull request #8 from mrmeku/tree_artifact
➜  bazel build test/petstore_java && file bazel-bin/test/petstore_java_codegen.srcjar
INFO: Analysed target //test:petstore_java (2 packages loaded, 10 targets configured).
INFO: Found 1 target...
INFO: Writing explanation of rebuilds to '/tmp/explain.log'
Target //test:petstore_java up-to-date:
  bazel-bin/test/petstore_java_codegen.srcjar
INFO: Elapsed time: 1.644s, Critical Path: 1.26s
INFO: 1 process: 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
bazel-bin/test/petstore_java_codegen.srcjar: Java archive data (JAR)
```

And after:

```
➜  git checkout 1c91e94b20e8ba216110057723d07c8db277dbb8
Previous HEAD position was 7e3e826 Merge pull request #8 from mrmeku/tree_artifact
HEAD is now at 1c91e94 Merge pull request #9 from mrmeku/gen_srcs
➜  bazel build test/petstore_java && file bazel-bin/test/petstore_java_codegen.srcjar
INFO: Analysed target //test:petstore_java (2 packages loaded, 10 targets configured).
INFO: Found 1 target...
INFO: Writing explanation of rebuilds to '/tmp/explain.log'
Target //test:petstore_java up-to-date:
  bazel-bin/test/petstore_java_codegen.srcjar
  bazel-bin/test/petstore_java_gen_dir
INFO: Elapsed time: 1.520s, Critical Path: 1.17s
INFO: 1 process: 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
bazel-bin/test/petstore_java_codegen.srcjar: Zip archive data (empty)
```

Whether this is reverted or fixed forward, it would be good to add a regression test. This could be tested by adding a basic `java_library()` that builds a Java file that refers to one of the classes generated by //test/petstore_java.