### PR TITLE
support both openapi and swaager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
+.PHONY: build
 build:
 	@bazel build //...
 
+.PHONY: test
 test:
 	@./test.sh
 
-.PHONY: build test
+.PHONY: clean
+clean:
+	@bazel clean
+	-@rm -f hash1
+	-@rm -f hash2
+
+default: build

--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -148,16 +148,6 @@ def _impl(ctx):
         codegen = ctx.outputs.codegen,
     )
 
-def _parse_verion(version):
-    """Parse the version string in a 3-tuple of ints
-    """
-    return tuple([int(n) for n in version.split(".")])
-
-def _is_at_least(threshold, version):
-    """Check that a version is higher or equals to a given version(threshold)
-    """
-    return _parse_verion(version) >= _parse_verion(threshold)
-
 # taken from rules_scala
 def _collect_jars(targets):
     """Compute the runtime and compile-time dependencies from the given targets"""  # noqa

--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -5,18 +5,32 @@
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
 # https://swagger.io/docs/open-source-tools/swagger-codegen/
-def openapi_repositories(swagger_codegen_cli_version = "2.4.9", swagger_codegen_cli_sha256 = "8555854798505f6ff924b55a95a7cc23d35b49aa9a62e8463b77da94b89b50b9", prefix = "io_bazel_rules_openapi"):
+# https://openapi-generator.tech/
+_SUPPORTED_PROVIDERS = {
+    "swagger": {
+        "artifact": "io.swagger:swagger-codegen-cli",
+        "name": "io_swagger_swagger_codegen_cli"
+    },
+    "openapi": {
+        "artifact": "org.openapitools:openapi-generator-cli",
+        "name": "org_openapitools_openapi_generator_cli"
+    }
+}
+
+def openapi_repositories(codegen_cli_version = "2.4.9", codegen_cli_sha256 = "8555854798505f6ff924b55a95a7cc23d35b49aa9a62e8463b77da94b89b50b9", prefix = "io_bazel_rules_openapi", codegen_cli_provider = "swagger"):
+
     jvm_maven_import_external(
-        name = prefix + "_io_swagger_swagger_codegen_cli",
-        artifact = "io.swagger:swagger-codegen-cli:" + swagger_codegen_cli_version,
-        artifact_sha256 = swagger_codegen_cli_sha256,
+        name = prefix + "_" + _SUPPORTED_PROVIDERS[codegen_cli_provider]["name"],
+        artifact = _SUPPORTED_PROVIDERS[codegen_cli_provider]["artifact"] + ":" + codegen_cli_version,
+        artifact_sha256 = codegen_cli_sha256,
         server_urls = ["https://repo.maven.apache.org/maven2"],
         licenses = ["notice"],  # Apache 2.0 License
     )
     native.bind(
         name = prefix + "/dependency/openapi-cli",
-        actual = "@" + prefix + "_io_swagger_swagger_codegen_cli//jar",
+        actual = "@" + prefix + "_" + _SUPPORTED_PROVIDERS[codegen_cli_provider]["name"] + "//jar",
     )
+
 
 def _comma_separated_pairs(pairs):
     return ",".join([
@@ -24,18 +38,39 @@ def _comma_separated_pairs(pairs):
         for k, v in pairs.items()
     ])
 
+def _generator_provider(ctx):
+    codegen_provider = "openapi"
+    if "io_swagger_swagger_codegen_cli" in ctx.file.codegen_cli.path:
+        codegen_provider = "swagger" 
+    return codegen_provider
+
+def _is_swagger_codegen(ctx):
+    return _generator_provider(ctx) == "swagger"
+
+def _is_openapi_codegen(ctx):
+    return _generator_provider(ctx) == "openapi"
+
 def _new_generator_command(ctx, gen_dir, rjars):
     java_path = ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path
     gen_cmd = str(java_path)
-
-    gen_cmd += " -cp {cli_jar}:{jars} io.swagger.codegen.SwaggerCodegen generate -i {spec} -l {language} -o {output}".format(
-        java = java_path,
+    gen_cmd += " -cp {cli_jar}:{jars}".format(
         cli_jar = ctx.file.codegen_cli.path,
         jars = ":".join([j.path for j in rjars.to_list()]),
-        spec = ctx.file.spec.path,
-        language = ctx.attr.language,
-        output = gen_dir,
     )
+
+    if _is_swagger_codegen(ctx):
+        gen_cmd += " io.swagger.codegen.SwaggerCodegen generate -i {spec} -l {language} -o {output}".format(
+            spec = ctx.file.spec.path,
+            language = ctx.attr.language,
+            output = gen_dir,
+        )
+    
+    if _is_openapi_codegen(ctx):
+        gen_cmd += " org.openapitools.codegen.OpenAPIGenerator generate -i {spec} -g {language} -o {output}".format(
+            spec = ctx.file.spec.path,
+            language = ctx.attr.language,
+            output = gen_dir,
+        )
 
     gen_cmd += ' -D "{properties}"'.format(
         properties = _comma_separated_pairs(ctx.attr.system_properties),
@@ -113,6 +148,16 @@ def _impl(ctx):
         codegen = ctx.outputs.codegen,
     )
 
+def _parse_verion(version):
+    """Parse the version string in a 3-tuple of ints
+    """
+    return tuple([int(n) for n in version.split(".")])
+
+def _is_at_least(threshold, version):
+    """Check that a version is higher or equals to a given version(threshold)
+    """
+    return _parse_verion(version) >= _parse_verion(threshold)
+
 # taken from rules_scala
 def _collect_jars(targets):
     """Compute the runtime and compile-time dependencies from the given targets"""  # noqa
@@ -160,6 +205,7 @@ openapi_gen = rule(
         "additional_properties": attr.string_dict(),
         "system_properties": attr.string_dict(),
         "type_mappings": attr.string_dict(),
+        "import_mappings": attr.string(),
         "_jdk": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
             providers = [java_common.JavaRuntimeInfo],

--- a/test.sh
+++ b/test.sh
@@ -3,12 +3,12 @@
 set -e
 
 md5_util() {
-if [[ "$OSTYPE" == "darwin"* ]]; then
-   _md5_util="md5"
-else
-   _md5_util="md5sum"
-fi
-echo "$_md5_util"
+  if [[ $OSTYPE == "darwin"* ]]; then
+    _md5_util="md5"
+  else
+    _md5_util="md5sum"
+  fi
+  echo "$_md5_util"
 }
 
 NC='\033[0m'
@@ -42,5 +42,63 @@ test_build_is_identical() {
   diff hash1 hash2
 }
 
+CODEGEN_CLI_VERSION_DEFAULT="2.4.9"
+CODEGEN_CLI_SHA256_DEFAULT="8555854798505f6ff924b55a95a7cc23d35b49aa9a62e8463b77da94b89b50b9"
+CODEGEN_CLI_PROVIDER_DEFAULT="swagger"
+test_version() {
+  local CODEGEN_CLI_VERSION=${1:-$CODEGEN_CLI_VERSION_DEFAULT}
+  local CODEGEN_CLI_SHA256=${2:-$CODEGEN_CLI_SHA256_DEFAULT}
+  local CODEGEN_CLI_PROVIDER=${3:-$CODEGEN_CLI_PROVIDER_DEFAULT}
+
+  cd "${dir}"/test_version
+  local timestamp=$(date +%s)
+  NEW_TEST_DIR="test_${CODEGEN_CLI_PROVIDER}_${CODEGEN_CLI_VERSION}_${timestamp}"
+  cp -r version_specific_tests_dir/ $NEW_TEST_DIR
+
+  sed \
+    -e "s/\${codegen_cli_version}/$CODEGEN_CLI_VERSION/" \
+    -e "s/\${codegen_cli_sha256}/$CODEGEN_CLI_SHA256/" \
+    -e "s/\${codegen_cli_provider}/$CODEGEN_CLI_PROVIDER/" \
+    WORKSPACE.template >> $NEW_TEST_DIR/WORKSPACE
+
+  cd $NEW_TEST_DIR
+
+  bazel build //...
+  $(md5_util) bazel-bin/test/*.{srcjar,jar} > hash1
+  bazel clean
+  bazel build //...
+  $(md5_util) bazel-bin/test/*.{srcjar,jar} > hash2
+  cat hash1 hash2
+  diff hash1 hash2
+
+  RESPONSE_CODE=$?
+  cd ..
+  rm -rf $NEW_TEST_DIR
+  exit $RESPONSE_CODE
+}
+
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
 run_test bazel build test/...
+
 run_test test_build_is_identical
+
+run_test test_version \
+  "2.4.9" \
+  "8555854798505f6ff924b55a95a7cc23d35b49aa9a62e8463b77da94b89b50b9" \
+  "swagger"
+
+run_test test_version \
+  "3.0.0-rc1" \
+  "867488b2df8c667c3f4b2b333eeee1fbcba76e92d6a29d300e01aedbfe34d6fe" \
+  "swagger"
+
+run_test test_version \
+  "3.3.4" \
+  "24cb04939110cffcdd7062d2f50c6f61159dc3e0ca3b8aecbae6ade53ad3dc8c" \
+  "openapi"
+
+run_test test_version \
+  "4.3.1" \
+  "f438cd16bc1db28d3363e314cefb59384f252361db9cb1a04a322e7eb5b331c1" \
+  "openapi"

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -1,0 +1,21 @@
+workspace(name = "openapi_test")
+
+local_repository(
+    name = "io_bazel_rules_openapi",
+    path = "../..",
+)
+
+
+load("@io_bazel_rules_openapi//openapi:openapi.bzl", "openapi_repositories")
+
+
+codegen_cli_version = "${codegen_cli_version}"
+codegen_cli_sha256 = "${codegen_cli_sha256}"
+codegen_cli_provider = "${codegen_cli_provider}"
+
+openapi_repositories(
+    codegen_cli_version = codegen_cli_version,
+    codegen_cli_sha256 = codegen_cli_sha256,
+    codegen_cli_provider = codegen_cli_provider,
+)
+

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_openapi//openapi:openapi.bzl", "openapi_gen")
+
+openapi_gen(
+    name = "petstore",
+    language = "go",
+    spec = "petstore.yaml",
+)
+
+openapi_gen(
+    name = "petstore_java",
+    language = "java",
+    spec = "petstore.yaml",
+)
+
+openapi_gen(
+    name = "petstore_java_feign",
+    additional_properties = {
+        "library": "feign",
+    },
+    language = "java",
+    spec = "petstore.yaml",
+)
+
+openapi_gen(
+    name = "petstore_java_no_tests",
+    language = "java",
+    spec = "petstore.yaml",
+    system_properties = {
+        "apiTests": "false",
+        "modelTests": "false",
+    },
+)
+
+openapi_gen(
+    name = "petstore_java_bigdecimal",
+    language = "java",
+    spec = "petstore.yaml",
+    type_mappings = {
+        "Integer": "java.math.BigDecimal",
+    },
+)

--- a/test_version/version_specific_tests_dir/petstore.yaml
+++ b/test_version/version_specific_tests_dir/petstore.yaml
@@ -1,0 +1,104 @@
+# https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/yaml/petstore.yaml
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    type: "object"
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    type: "object"
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string


### PR DESCRIPTION
- support two providers by asking user to provide a
   provider[swagger, openapi] during the init the repository