### PR TITLE
Add spec_refs to support relative $ref

### DIFF
--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -136,7 +136,7 @@ def _impl(ctx):
     inputs = ctx.files._jdk + [
         ctx.file.codegen_cli,
         ctx.file.spec,
-    ] + cjars.to_list() + rjars.to_list()
+    ] + _collect_files(ctx.attr.spec_refs) + cjars.to_list() + rjars.to_list()
     ctx.actions.run_shell(
         inputs = inputs,
         outputs = [ctx.actions.declare_directory("%s" % (ctx.attr.name)), ctx.outputs.codegen],
@@ -178,6 +178,12 @@ def _collect_jars(targets):
 
     return struct(compiletime = compile_jars, runtime = runtime_jars)
 
+def _collect_files(targets):
+    result = []
+    for target in targets:
+       result += target.files.to_list()
+    return result
+
 openapi_gen = rule(
     attrs = {
         # downstream dependencies
@@ -186,6 +192,11 @@ openapi_gen = rule(
         "spec": attr.label(
             mandatory = True,
             allow_single_file = [".json", ".yaml"],
+        ),
+        "spec_refs": attr.label_list(
+            allow_empty = True,
+            allow_files = [".json", ".yaml"],
+            default = [],
         ),
         # language to generate
         "language": attr.string(mandatory = True),


### PR DESCRIPTION
In order to be able to have refer to an external schema file, for
example:

```
    schema:
      $ref: "./schema.json#/definitions/MyExternalType"
```

in the OpenAPI definition, also the external dependencies need to be
copied to Bazel's private tmp cache.

To do this, a schema_refs attribute is added, and can be used like:

```
    openapi_gen(
      ...
      spec = "openapi.yaml",
      spec_refs = ["schema.json"]
    )
```