### PR TITLE
[openapi] Add support for openapi-generator 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Rules](#rules)
 - [Getting started](#getting-started)
 - [Bazel compatibility matrix](#bazel-compatibility-matrix)
+- [OpenAPI generator](#openapi-generator)
 - [openapi_gen](#openapi_gen)
 
 ## Rules
@@ -52,6 +53,23 @@ load("@io_bazel_rules_openapi//openapi:openapi.bzl", "openapi_gen")
 | 3.0.0         | 2528ecbfe628211de87e1924908350014fb0d03e | d4c5b924f0a2a7d844650ff3b76c0475f370e5ceb5b1811665144102e7296383 |
 | 3.6.0         | 112663e9935f4711c7c14c3357f8e4547d43cd8c | cf32217fda600e49848cd9b496a2e77e50d695230f437f8d5a2f0f2f5d437338 |
 | 3.7.0         | f0f42afb855139ad5346659d089c32fb756d068e | 9570186948f1f65c61d2c6c6006840ea70888b270f028bbd0eb736caae1cd9df |
+
+## OpenAPI generator
+
+By default the code will be generated using [Swagger's codegen](https://github.com/swagger-api/swagger-codegen#swagger-code-generator) it is however possible to switch
+to [OpenAPI's generator](https://github.com/OpenAPITools/openapi-generator). This can be done by passing some parameters to the `openapi_repositories` function:
+
+WORKSPACE:
+```python
+load("@io_bazel_rules_openapi//openapi:openapi.bzl", "openapi_repositories")
+openapi_repositories(
+    codegen_cli_version = "5.0.0",
+    codegen_cli_sha256 = "839fade01e54ce1eecf012b8c33adb1413cff0cf2e76e23bc8d7673f09626f8e",
+    codegen_cli_provider = "openapi"
+)
+```
+
+For most languages, changing the generator should be seamless. You might however need to change the `language` field in you rule to match one available on the selected generator.
 
 ## openapi_gen
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,3 +3,17 @@ workspace(name = "io_bazel_rules_openapi")
 load("//openapi:openapi.bzl", "openapi_repositories")
 
 openapi_repositories()
+
+openapi_repositories(
+    codegen_cli_version = "4.3.1",
+    codegen_cli_sha256 = "f438cd16bc1db28d3363e314cefb59384f252361db9cb1a04a322e7eb5b331c1",
+    prefix = "io_bazel_rules_openapi_openapi_4",
+    codegen_cli_provider = "openapi"
+)
+
+openapi_repositories(
+    codegen_cli_version = "5.0.0",
+    codegen_cli_sha256 = "839fade01e54ce1eecf012b8c33adb1413cff0cf2e76e23bc8d7673f09626f8e",
+    prefix = "io_bazel_rules_openapi_openapi_5",
+    codegen_cli_provider = "openapi"
+)

--- a/test.sh
+++ b/test.sh
@@ -64,10 +64,10 @@ test_version() {
   cd $NEW_TEST_DIR
 
   bazel build //...
-  $(md5_util) bazel-bin/test/*.{srcjar,jar} > hash1
+  $(md5_util) bazel-bin/*.{srcjar,jar} > hash1
   bazel clean
   bazel build //...
-  $(md5_util) bazel-bin/test/*.{srcjar,jar} > hash2
+  $(md5_util) bazel-bin/*.{srcjar,jar} > hash2
   cat hash1 hash2
   diff hash1 hash2
 
@@ -102,3 +102,9 @@ run_test test_version \
   "4.3.1" \
   "f438cd16bc1db28d3363e314cefb59384f252361db9cb1a04a322e7eb5b331c1" \
   "openapi"
+
+run_test test_version \
+  "5.0.0" \
+  "839fade01e54ce1eecf012b8c33adb1413cff0cf2e76e23bc8d7673f09626f8e" \
+  "openapi"
+

--- a/test/BUILD
+++ b/test/BUILD
@@ -39,3 +39,25 @@ openapi_gen(
         "Integer": "java.math.BigDecimal",
     },
 )
+
+openapi_gen(
+    name = "petstore_scala_openapi_5",
+    language = "scala-sttp",
+    spec = "petstore.yaml",
+    codegen_cli = "//external:io_bazel_rules_openapi_openapi_5/dependency/openapi-cli",
+    additional_properties = {
+        "jsonLibrary": "circe",
+        "sttpClientVersion": "2.2.0"
+    },
+)
+
+openapi_gen(
+    name = "petstore_scala_openapi_4",
+    language = "scala-sttp",
+    spec = "petstore.yaml",
+    codegen_cli = "//external:io_bazel_rules_openapi_openapi_4/dependency/openapi-cli",
+    additional_properties = {
+        "jsonLibrary": "circe",
+        "sttpClientVersion": "2.2.0"
+    },
+)


### PR DESCRIPTION
The CLI of openapi generator changed a bit with the 5.0.0 release.
As mention [here](https://github.com/OpenAPITools/openapi-generator/blob/150e24dc553a8ea5230ffb938ed3e6020e972faa/docs/global-properties.md#note-on-global-property-declaration), the global property must now be provided using the `--global-property` flag instead of `-D`.

Documentation was updated as well as some tests with specific openapi-cli versions.

The parsing of the version from the jar might not be resilient (if the version number contains a `-` for instance) but regular expression are not available in Starlark.

The `Bazel compatibility matrix` will probably need an update once this commit is merged.