### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -123,7 +123,7 @@ def _impl(ctx):
         ),
         _new_generator_command(ctx, gen_dir, rjars),
         # forcing a timestamp for deterministic artifacts
-        "find {gen_dir} -exec touch -t 198001010000 {{}} \;".format(
+        "find {gen_dir} -exec touch -t 198001010000 {{}} \\;".format(
             gen_dir = gen_dir,
         ),
         "{jar} cMf {target} -C {srcs} .".format(


### PR DESCRIPTION
I'm running into this error: 
`.../io_bazel_rules_openapi/openapi/openapi.bzl:126:59: invalid escape sequence: \;. You can enable unknown escape sequences by passing the flag --incompatible_restrict_string_escapes=false`

Backslash needs to be escaped.