### PR TITLE
Add support for swagger codegen 3.x

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,3 +17,10 @@ openapi_repositories(
     prefix = "io_bazel_rules_openapi_openapi_5",
     codegen_cli_provider = "openapi"
 )
+
+openapi_repositories(
+    codegen_cli_provider = "swaggerv3",
+    codegen_cli_sha256 = "5480e649661f132bdc547cd4ec3a7f334b9f57a33ee9b3e857af9c7b5f5be6c2",
+    codegen_cli_version = "3.0.43",
+    prefix = "io_bazel_rules_openapi_swagger_3_0_43",
+)

--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -11,6 +11,10 @@ _SUPPORTED_PROVIDERS = {
         "artifact": "io.swagger:swagger-codegen-cli",
         "name": "io_swagger_swagger_codegen_cli"
     },
+    "swaggerv3": {
+        "artifact": "io.swagger.codegen.v3:swagger-codegen-cli",
+        "name": "io_swagger_codegen_v3_swagger_codegen_cli"
+    },
     "openapi": {
         "artifact": "org.openapitools:openapi-generator-cli",
         "name": "org_openapitools_openapi_generator_cli"
@@ -42,10 +46,15 @@ def _generator_provider(ctx):
     codegen_provider = "openapi"
     if "io_swagger_swagger_codegen_cli" in ctx.file.codegen_cli.path:
         codegen_provider = "swagger"
+    if "io_swagger_codegen_v3_swagger_codegen_cli" in ctx.file.codegen_cli.path:
+        codegen_provider = "swaggerv3"
     return codegen_provider
 
 def _is_swagger_codegen(ctx):
     return _generator_provider(ctx) == "swagger"
+
+def _is_swagger_codegen_v3(ctx):
+    return _generator_provider(ctx) == "swaggerv3"
 
 def _is_openapi_codegen(ctx):
     return _generator_provider(ctx) == "openapi"
@@ -69,6 +78,16 @@ def _new_generator_command(ctx, gen_dir, rjars):
 
     if _is_swagger_codegen(ctx):
         gen_cmd += " io.swagger.codegen.SwaggerCodegen generate -i {spec} -l {language} -o {output}".format(
+            spec = ctx.file.spec.path,
+            language = ctx.attr.language,
+            output = gen_dir,
+        )
+        gen_cmd += ' -D "{properties}"'.format(
+            properties = _comma_separated_pairs(ctx.attr.system_properties),
+        )
+
+    if _is_swagger_codegen_v3(ctx):
+        gen_cmd += " io.swagger.codegen.v3.cli.SwaggerCodegen generate -i {spec} -l {language} -o {output}".format(
             spec = ctx.file.spec.path,
             language = ctx.attr.language,
             output = gen_dir,

--- a/test.sh
+++ b/test.sh
@@ -108,3 +108,7 @@ run_test test_version \
   "839fade01e54ce1eecf012b8c33adb1413cff0cf2e76e23bc8d7673f09626f8e" \
   "openapi"
 
+run_test test_version \
+  "3.0.43" \
+  "5480e649661f132bdc547cd4ec3a7f334b9f57a33ee9b3e857af9c7b5f5be6c2" \
+  "swaggerv3"

--- a/test/BUILD
+++ b/test/BUILD
@@ -61,3 +61,10 @@ openapi_gen(
         "sttpClientVersion": "2.2.0"
     },
 )
+
+openapi_gen(
+    name = "petstore_java_swagger3",
+    language = "java",
+    spec = "petstore.yaml",
+    codegen_cli = "//external:io_bazel_rules_openapi_swagger_3_0_43/dependency/openapi-cli",
+)


### PR DESCRIPTION
The maven and java package coordinates for swagger codegen 3.x have changed since 2.x (io.swagger:swagger-codegen-cli -> io.swagger.codegen.v3:swagger-codegen-cli, io.swagger.codegen.SwaggerCodegen -> io.swagger.codegen.v3.cli.SwaggerCodegen, respectively), so the .bzl file needs to be updated to support this.