### PR TITLE
chore: switch renovate to config:best-practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ]
+    "config:best-practices"
+  ],
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": false,
+  "minimumReleaseAge": "2 days",
+  "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
Modernize Renovate config:

- `config:base` (deprecated) → `config:best-practices` (enables SHA pinning for GitHub Actions)
- Add `automerge: true`, `automergeType: pr`, `platformAutomerge: false`
- Add `minimumReleaseAge: 2 days` soak time
- Add `internalChecksFilter: strict`
- Add `$schema` for editor validation

Renovate will open follow-up PRs to pin existing deps to SHA digests.